### PR TITLE
Try building v1.8.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -14,7 +14,7 @@ mxnet_blas_impl:
   - openblas
   - mkl
 mxnet_version:
-  - 1.5.0
+  - 1.8.0
 #cudatoolkit_version:
 #  - 8.0
 #  - 9.0

--- a/libmxnet/meta.yaml
+++ b/libmxnet/meta.yaml
@@ -5,10 +5,10 @@ package:
   version: {{ mxnet_version }}
 
 source:
-  #git_url: https://github.com/apache/incubator-mxnet.git
-  #git_rev: {{ mxnet_version }}
-  url: https://github.com/apache/incubator-mxnet/releases/download/{{ mxnet_version }}/apache-mxnet-src-{{ mxnet_version }}-incubating.tar.gz
-  sha256: 67a23738fc5e0b1d0fa5d67d079f85230fe26d53a6c2e46439441f62ce2a53b2
+  git_url: https://github.com/apache/incubator-mxnet.git
+  git_rev: {{ mxnet_version }}
+  #url: https://github.com/apache/incubator-mxnet/releases/download/{{ mxnet_version }}/apache-mxnet-src-{{ mxnet_version }}-incubating.tar.gz
+  #sha256: 67a23738fc5e0b1d0fa5d67d079f85230fe26d53a6c2e46439441f62ce2a53b2
   patches:
     - 0001-use-external-mklml-and-mkldnn-libraries.patch
 


### PR DESCRIPTION
This version _should_ build on `linux-64` and `osx-64`.
NOTE: The mxnet project does **not** support linux-aarch64 at v1.8.0.